### PR TITLE
References egress-mapping modifierPrefixMap in patient search

### DIFF
--- a/fhir-mapping/src/main/ml-modules/root/data-services/patient/search.sjs
+++ b/fhir-mapping/src/main/ml-modules/root/data-services/patient/search.sjs
@@ -56,7 +56,7 @@ const query = cts.andQuery([
 
     if (prefixedSearchTerms.has(field)) {
       const xsConverterFn = prefixedSearchTerms.get(field);
-      return cts.jsonPropertyRangeQuery(fieldMap.get(field), modifierPrefixMap.get(modifier), xs[xsConverterFn](values[0]))
+      return cts.jsonPropertyRangeQuery(fieldMap.get(field), egress.modifierPrefixMap.get(modifier) || modifier, xs[xsConverterFn](values[0]))
     } else if (identifierSearchTerms.has(field)) {
       const identifiers = values.map(valueString => {
         // Look for | to see if there is a code system or a type system specified in the query and split the string at the index, if found

--- a/hapi-server/src/main/java/com/marklogic/util/SearchCriteria.java
+++ b/hapi-server/src/main/java/com/marklogic/util/SearchCriteria.java
@@ -136,11 +136,11 @@ public class SearchCriteria {
     // https://www.hl7.org/fhir/search.html#prefix
     private static Map<String, String> dateModifierMap = Map.ofEntries(
         // Date & Numeric
-        entry(ParamPrefixEnum.EQUAL.toString(), "="),
-        entry(ParamPrefixEnum.GREATERTHAN_OR_EQUALS.toString(), ">="),
-        entry(ParamPrefixEnum.GREATERTHAN.toString(), ">"),
-        entry(ParamPrefixEnum.LESSTHAN_OR_EQUALS.toString(), "<="),
-        entry(ParamPrefixEnum.LESSTHAN.toString(), "<"),
+        entry(ParamPrefixEnum.EQUAL.toString(), "eq"),
+        entry(ParamPrefixEnum.GREATERTHAN_OR_EQUALS.toString(), "ge"),
+        entry(ParamPrefixEnum.GREATERTHAN.toString(), "gt"),
+        entry(ParamPrefixEnum.LESSTHAN_OR_EQUALS.toString(), "le"),
+        entry(ParamPrefixEnum.LESSTHAN.toString(), "lt"),
         entry(ParamPrefixEnum.NOT_EQUAL.toString(), "ne"),
         entry(ParamPrefixEnum.APPROXIMATE.toString(), "ap"),
         // Period


### PR DESCRIPTION
Modifies HAPI server code to send HL7-compliant date modifiers and have
all translation to symbolic modifiers occur in patient search, with a
fallback in case a symbolic modifier is sent by the HAPI server